### PR TITLE
Include default libraries when compiling armv6k-nintendo-3ds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "libc"
 version = "0.2.105"
-source = "git+https://github.com/Meziu/libc#b3363cd730adf81b46194f483f2afd7b84bbf78e"
+source = "git+https://github.com/Meziu/libc#2de354450c6583858329866ee2eaa33852775d21"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
@@ -36,6 +36,7 @@ pub fn target() -> Target {
             features: "+vfp2".to_string(),
             pre_link_args,
             exe_suffix: ".elf".to_string(),
+            no_default_libraries: false,
             ..Default::default()
         },
     }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.108", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { git = "https://github.com/Meziu/libc", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.66" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }


### PR DESCRIPTION
This removes the need for `-C default-linker-libraries` in `cargo-3ds`. It makes sense to do this anyways because the target is always cross compiled to (no fear of including unwanted system libraries), and the default linker libraries fill in some missing symbols.

Also fixed the dependency specification for libc and updated it to the latest commit.