### PR TITLE
Fix merge conflicts and multiple libc dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.108",
+ "libc",
  "winapi",
 ]
 
@@ -227,13 +227,7 @@ dependencies = [
  "filetime",
  "getopts",
  "ignore",
-<<<<<<< HEAD
  "libc",
-=======
- "lazy_static",
- "libc 0.2.108",
- "merge",
->>>>>>> 58e020def34 (Horizon OS STD support)
  "num_cpus",
  "once_cell",
  "opener",
@@ -362,7 +356,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "lazycell",
- "libc 0.2.108",
+ "libc",
  "libgit2-sys",
  "log",
  "memchr",
@@ -483,7 +477,7 @@ dependencies = [
  "filetime",
  "hex 0.4.2",
  "jobserver",
- "libc 0.2.108",
+ "libc",
  "log",
  "miow",
  "same-file",
@@ -605,7 +599,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "num-integer",
  "num-traits",
  "time",
@@ -734,7 +728,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -756,7 +750,7 @@ dependencies = [
  "getopts",
  "glob",
  "lazy_static",
- "libc 0.2.108",
+ "libc",
  "miow",
  "regex",
  "rustfix 0.6.0",
@@ -779,7 +773,7 @@ dependencies = [
  "filetime",
  "getopts",
  "lazy_static",
- "libc 0.2.108",
+ "libc",
  "log",
  "miow",
  "regex",
@@ -806,7 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -929,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
 dependencies = [
  "curl-sys",
- "libc 0.2.108",
+ "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
@@ -944,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
 dependencies = [
  "cc",
- "libc 0.2.108",
+ "libc",
  "libnghttp2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1046,7 +1040,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "redox_users",
  "winapi",
 ]
@@ -1057,7 +1051,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "redox_users",
  "winapi",
 ]
@@ -1069,7 +1063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fe28e0bf9357092740362502f5cc7955d8dc125ebda71dec72336c2e15c62e"
 dependencies = [
  "compiler_builtins",
- "libc 0.2.108",
+ "libc",
  "rustc-std-workspace-core",
 ]
 
@@ -1207,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.108",
+ "libc",
  "redox_syscall",
  "winapi",
 ]
@@ -1226,7 +1220,7 @@ checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc 0.2.108",
+ "libc",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1450,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.108",
+ "libc",
  "wasi",
 ]
 
@@ -1461,7 +1455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.108",
+ "libc",
  "wasi",
 ]
 
@@ -1506,7 +1500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
 dependencies = [
  "bitflags",
- "libc 0.2.108",
+ "libc",
  "libgit2-sys",
  "log",
  "openssl-probe",
@@ -1596,7 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "compiler_builtins",
- "libc 0.2.108",
+ "libc",
  "rustc-std-workspace-core",
 ]
 
@@ -1793,7 +1787,7 @@ version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -1946,17 +1940,8 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
-source = "git+https://github.com/Meziu/libc#2de354450c6583858329866ee2eaa33852775d21"
-dependencies = [
- "rustc-std-workspace-core",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.108"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+version = "0.2.113"
+source = "git+https://github.com/Meziu/libc#98ef7e73e32139fb5cf47df40421b5dc88c9434f"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -1968,7 +1953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
 dependencies = [
  "cc",
- "libc 0.2.108",
+ "libc",
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1998,7 +1983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
 dependencies = [
  "cc",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -2008,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
 dependencies = [
  "cc",
- "libc 0.2.108",
+ "libc",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -2022,7 +2007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
- "libc 0.2.108",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2103,7 +2088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
 dependencies = [
  "cc",
- "libc 0.2.108",
+ "libc",
  "pkg-config",
 ]
 
@@ -2252,7 +2237,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e3e85b970d650e2ae6d70592474087051c11c54da7f7b4949725c5735fbcc6"
 dependencies = [
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -2297,7 +2282,7 @@ version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "log",
  "miow",
  "ntapi",
@@ -2322,7 +2307,7 @@ dependencies = [
  "env_logger 0.9.0",
  "getrandom 0.2.0",
  "hex 0.4.2",
- "libc 0.2.108",
+ "libc",
  "log",
  "measureme 9.1.2",
  "rand 0.8.4",
@@ -2384,7 +2369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -2469,7 +2454,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
- "libc 0.2.108",
+ "libc",
  "once_cell",
  "openssl-sys",
 ]
@@ -2497,7 +2482,7 @@ checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.108",
+ "libc",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2547,7 +2532,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -2558,7 +2543,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.108",
+ "libc",
  "unwind",
 ]
 
@@ -2569,7 +2554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
 dependencies = [
  "futures 0.3.12",
- "libc 0.2.108",
+ "libc",
  "log",
  "rand 0.7.3",
  "tokio",
@@ -2595,7 +2580,7 @@ checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc 0.2.108",
+ "libc",
  "redox_syscall",
  "smallvec",
  "winapi",
@@ -2625,7 +2610,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
 dependencies = [
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -2940,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.14",
- "libc 0.2.108",
+ "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -2953,7 +2938,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "rand_chacha 0.3.0",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
@@ -3278,255 +3263,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "rustc-ap-rustc_arena"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550ca1a0925d31a0af089b18c89f5adf3b286e319e3e1f1a5204c21bd2f17371"
-dependencies = [
- "rustc-ap-rustc_data_structures",
- "smallvec",
-]
-
-[[package]]
-name = "rustc-ap-rustc_ast"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa53b68080df17994a54747f7c37b0686288a670efb9ba3b382ce62e744aed2"
-dependencies = [
- "bitflags",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_index",
- "rustc-ap-rustc_lexer",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "rustc-ap-rustc_span",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "rustc-ap-rustc_ast_pretty"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae71e68fada466a4b2c39c79ca6aee3226587abe6787170d2f6c92237569565"
-dependencies = [
- "rustc-ap-rustc_ast",
- "rustc-ap-rustc_span",
- "tracing",
-]
-
-[[package]]
-name = "rustc-ap-rustc_data_structures"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa484d6e0ca32d1d82303647275c696f745599b3d97e686f396ceef5b99d7ae"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.8.3",
- "ena",
- "indexmap",
- "jobserver",
- "libc 0.2.108",
- "measureme 9.1.2",
- "memmap2",
- "parking_lot",
- "rustc-ap-rustc_graphviz",
- "rustc-ap-rustc_index",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "rustc-hash",
- "rustc-rayon",
- "rustc-rayon-core",
- "smallvec",
- "stable_deref_trait",
- "stacker",
- "tempfile",
- "tracing",
- "winapi",
-]
-
-[[package]]
-name = "rustc-ap-rustc_errors"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f85ba19cca320ad797e3a29c35cab9bddfff0e7adbde336a436249e54cee7b1"
-dependencies = [
- "annotate-snippets",
- "atty",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_lint_defs",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "rustc-ap-rustc_span",
- "termcolor",
- "termize",
- "tracing",
- "unicode-width",
- "winapi",
-]
-
-[[package]]
-name = "rustc-ap-rustc_feature"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d538adab96b8b2b1ca9fcd4c8c47d4e23e862a23d1a38b6c15cd8fd52b34b1"
-dependencies = [
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_span",
-]
-
-[[package]]
-name = "rustc-ap-rustc_fs_util"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad6f13d240944fa8f360d2f3b849a7cadaec75e477829e7dde61e838deda83d"
-
-[[package]]
-name = "rustc-ap-rustc_graphviz"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b3451153cc5828c02cc4f1a0df146d25ac4b3382a112e25fd9d3f5bff15cdc"
-
-[[package]]
-name = "rustc-ap-rustc_index"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd39a9f01b442c629bdff5778cb3dd29b7c2ea4afe62d5ab61d216bd1b556692"
-dependencies = [
- "arrayvec",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
-]
-
-[[package]]
-name = "rustc-ap-rustc_lexer"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5de290c44a90e671d2cd730062b9ef73d11155da7e44e7741d633e1e51e616e"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "rustc-ap-rustc_lint_defs"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69570b4beb61088926b131579865bbe70d124d30778c46307a62ec8b310ae462"
-dependencies = [
- "rustc-ap-rustc_ast",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "rustc-ap-rustc_span",
- "rustc-ap-rustc_target",
- "tracing",
-]
-
-[[package]]
-name = "rustc-ap-rustc_macros"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd877df37f15c5a44d9679d1b5207ebc95f3943fbc336eeac670195ac58610"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "rustc-ap-rustc_parse"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02502d8522ba31d0bcad28a78822b68c1b6ba947a2b4aa6a2341b30594379b80"
-dependencies = [
- "bitflags",
- "rustc-ap-rustc_ast",
- "rustc-ap-rustc_ast_pretty",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_errors",
- "rustc-ap-rustc_feature",
- "rustc-ap-rustc_lexer",
- "rustc-ap-rustc_session",
- "rustc-ap-rustc_span",
- "smallvec",
- "tracing",
- "unicode-normalization",
-]
-
-[[package]]
-name = "rustc-ap-rustc_serialize"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f741f8e9aee6323fbe127329490608a5a250cc0072ac91e684ef62518cdb1ff"
-dependencies = [
- "indexmap",
- "smallvec",
-]
-
-[[package]]
-name = "rustc-ap-rustc_session"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba61eca749f4fced4427ad1cc7f23342cfc6527c3bcc624e3aa56abc1f81298"
-dependencies = [
- "bitflags",
- "getopts",
- "num_cpus",
- "rustc-ap-rustc_ast",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_errors",
- "rustc-ap-rustc_feature",
- "rustc-ap-rustc_fs_util",
- "rustc-ap-rustc_lint_defs",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "rustc-ap-rustc_span",
- "rustc-ap-rustc_target",
- "tracing",
-]
-
-[[package]]
-name = "rustc-ap-rustc_span"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a642e8d6fc883f34e0778e079f8242ac40c6614a6b7a0ef61681333e847f5e62"
-dependencies = [
- "cfg-if 0.1.10",
- "md-5",
- "rustc-ap-rustc_arena",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_index",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "scoped-tls",
- "sha-1 0.9.1",
- "sha2",
- "tracing",
- "unicode-width",
-]
-
-[[package]]
-name = "rustc-ap-rustc_target"
-version = "722.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80feebd8c323b80dd73a395fa7fabba9e2098b6277670ff89c473f618ffa07de"
-dependencies = [
- "bitflags",
- "rustc-ap-rustc_data_structures",
- "rustc-ap-rustc_index",
- "rustc-ap-rustc_macros",
- "rustc-ap-rustc_serialize",
- "rustc-ap-rustc_span",
- "tracing",
-]
-
-[[package]]
->>>>>>> 3c47f8555f3 (Use Git dependency for patched libc)
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,13 +3344,8 @@ version = "1.0.0"
 dependencies = [
  "bstr",
  "byteorder",
-<<<<<<< HEAD
  "crossbeam-utils",
  "libc",
-=======
- "crossbeam-utils 0.8.3",
- "libc 0.2.108",
->>>>>>> 3c47f8555f3 (Use Git dependency for patched libc)
  "libz-sys",
  "proc-macro2",
  "quote",
@@ -3775,7 +3506,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "cstr",
- "libc 0.2.108",
+ "libc",
  "libloading",
  "measureme 10.0.0",
  "rustc-demangle",
@@ -3808,13 +3539,8 @@ dependencies = [
  "cc",
  "itertools 0.9.0",
  "jobserver",
-<<<<<<< HEAD
  "libc",
  "object 0.28.1",
-=======
- "libc 0.2.108",
- "object",
->>>>>>> 3c47f8555f3 (Use Git dependency for patched libc)
  "pathdiff",
  "regex",
  "rustc_apfloat",
@@ -3876,7 +3602,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc 0.2.108",
+ "libc",
  "measureme 10.0.0",
  "memmap2",
  "parking_lot",
@@ -3899,12 +3625,7 @@ dependencies = [
 name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
-<<<<<<< HEAD
  "libc",
-=======
- "atty",
- "libc 0.2.108",
->>>>>>> 3c47f8555f3 (Use Git dependency for patched libc)
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_codegen_ssa",
@@ -4071,7 +3792,7 @@ dependencies = [
 name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "libloading",
  "rustc-rayon",
  "rustc-rayon-core",
@@ -4168,7 +3889,7 @@ version = "0.0.0"
 dependencies = [
  "build_helper",
  "cc",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -4850,7 +4571,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.108",
+ "libc",
  "security-framework-sys",
 ]
 
@@ -4861,7 +4582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -5009,7 +4730,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -5052,7 +4773,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "winapi",
 ]
 
@@ -5070,7 +4791,7 @@ checksum = "90939d5171a4420b3ff5fbc8954d641e7377335454c259dcb80786f3f21dc9b4"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
- "libc 0.2.108",
+ "libc",
  "psm",
  "winapi",
 ]
@@ -5088,7 +4809,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown",
  "hermit-abi",
- "libc 0.2.105",
+ "libc",
  "miniz_oxide",
  "object 0.26.2",
  "panic_abort",
@@ -5107,7 +4828,7 @@ version = "0.1.5"
 dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
- "libc 0.2.108",
+ "libc",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
@@ -5224,7 +4945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
 dependencies = [
  "filetime",
- "libc 0.2.108",
+ "libc",
  "xattr",
 ]
 
@@ -5235,7 +4956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
- "libc 0.2.108",
+ "libc",
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
@@ -5289,7 +5010,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "winapi",
 ]
 
@@ -5300,7 +5021,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "core",
  "getopts",
- "libc 0.2.108",
+ "libc",
  "panic_abort",
  "panic_unwind",
  "proc_macro",
@@ -5315,7 +5036,7 @@ checksum = "0639d10d8f4615f223a57275cf40f9bdb7cfbb806bcb7f7cc56e3beb55a576eb"
 dependencies = [
  "cfg-if 1.0.0",
  "getopts",
- "libc 0.2.108",
+ "libc",
  "num_cpus",
  "term 0.7.0",
 ]
@@ -5393,7 +5114,7 @@ checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -5402,7 +5123,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "tikv-jemalloc-sys",
 ]
 
@@ -5412,7 +5133,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.108",
+ "libc",
  "winapi",
 ]
 
@@ -5430,7 +5151,7 @@ checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
  "autocfg",
  "bytes",
- "libc 0.2.108",
+ "libc",
  "memchr",
  "mio",
  "num_cpus",
@@ -5734,7 +5455,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]
@@ -5874,7 +5595,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc 0.2.108",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,5 +131,8 @@ rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
 
+# 3DS changes havne't merged to libc upstream yet
+libc = { git = "https://github.com/Meziu/libc" }
+
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }


### PR DESCRIPTION
This updates the libc dependency to use the patch mechanism at the workspace level. Previously there were two versions of libc in use, and now there is just one.

The patch must still happen in the std Cargo.toml and not just the workspace level Cargo.toml because of this build-std limitation:
https://github.com/rust-lang/wg-cargo-std-aware/issues/78#issuecomment-1013894681
