### PR TITLE
Use the right wait_timeout implementation

### DIFF
--- a/library/std/src/sys/unix/condvar.rs
+++ b/library/std/src/sys/unix/condvar.rs
@@ -15,11 +15,7 @@ const TIMESPEC_MAX: libc::timespec =
     libc::timespec { tv_sec: <libc::time_t>::MAX, tv_nsec: 1_000_000_000 - 1 };
 
 fn saturating_cast_to_time_t(value: u64) -> libc::time_t {
-    if value > <libc::time_t>::MAX as u64 {
-        <libc::time_t>::MAX
-    } else {
-        value as libc::time_t
-    }
+    if value > <libc::time_t>::MAX as u64 { <libc::time_t>::MAX } else { value as libc::time_t }
 }
 
 impl Condvar {

--- a/library/std/src/sys/unix/condvar.rs
+++ b/library/std/src/sys/unix/condvar.rs
@@ -15,7 +15,11 @@ const TIMESPEC_MAX: libc::timespec =
     libc::timespec { tv_sec: <libc::time_t>::MAX, tv_nsec: 1_000_000_000 - 1 };
 
 fn saturating_cast_to_time_t(value: u64) -> libc::time_t {
-    if value > <libc::time_t>::MAX as u64 { <libc::time_t>::MAX } else { value as libc::time_t }
+    if value > <libc::time_t>::MAX as u64 {
+        <libc::time_t>::MAX
+    } else {
+        value as libc::time_t
+    }
 }
 
 impl Condvar {
@@ -38,6 +42,8 @@ impl Condvar {
     // So on that platform, init() should always be called
     // Moreover, that platform does not have pthread_condattr_setclock support,
     // hence that initialization should be skipped as well
+    //
+    // Similar story for the 3DS (horizon).
     #[cfg(any(target_os = "espidf", target_os = "horizon"))]
     pub unsafe fn init(&mut self) {
         let r = libc::pthread_cond_init(self.inner.get(), crate::ptr::null());
@@ -92,7 +98,8 @@ impl Condvar {
         target_os = "macos",
         target_os = "ios",
         target_os = "android",
-        target_os = "espidf"
+        target_os = "espidf",
+        target_os = "horizon"
     )))]
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, dur: Duration) -> bool {
         use crate::mem;
@@ -124,7 +131,8 @@ impl Condvar {
         target_os = "macos",
         target_os = "ios",
         target_os = "android",
-        target_os = "espidf"
+        target_os = "espidf",
+        target_os = "horizon"
     ))]
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, mut dur: Duration) -> bool {
         use crate::ptr;


### PR DESCRIPTION
Our condvar doesn't support setting attributes, like `pthread_condattr_setclock`, which the current wait_timeout expects to have configured.

Switch to a different implementation, following espidf.

Unfortunately this doesn't fix the tokio example, but it does stop the release build's runtime thread from panicking (still doesn't print "Tick").