### PR TITLE
Enable argv support for horizon OS

### DIFF
--- a/library/std/src/sys/unix/args.rs
+++ b/library/std/src/sys/unix/args.rs
@@ -68,7 +68,8 @@ impl DoubleEndedIterator for Args {
     target_os = "l4re",
     target_os = "fuchsia",
     target_os = "redox",
-    target_os = "vxworks"
+    target_os = "vxworks",
+    target_os = "horizon"
 ))]
 mod imp {
     use super::Args;
@@ -247,7 +248,7 @@ mod imp {
     }
 }
 
-#[cfg(any(target_os = "espidf", target_os = "horizon"))]
+#[cfg(any(target_os = "espidf"))]
 mod imp {
     use super::Args;
 

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -44,10 +44,10 @@ pub mod thread_local_dtor;
 pub mod thread_local_key;
 pub mod time;
 
-#[cfg(any(target_os = "espidf", target_os = "horizon"))]
+#[cfg(target_os = "espidf")]
 pub fn init(argc: isize, argv: *const *const u8) {}
 
-#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+#[cfg(not(target_os = "espidf"))]
 // SAFETY: must be called only once during runtime initialization.
 // NOTE: this is not guaranteed to run, for example when Rust code is called externally.
 pub unsafe fn init(argc: isize, argv: *const *const u8) {
@@ -76,6 +76,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8) {
                 target_os = "emscripten",
                 target_os = "fuchsia",
                 target_os = "vxworks",
+                target_os = "horizon",
                 // The poll on Darwin doesn't set POLLNVAL for closed fds.
                 target_os = "macos",
                 target_os = "ios",
@@ -119,7 +120,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8) {
     }
 
     unsafe fn reset_sigpipe() {
-        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia")))]
+        #[cfg(not(any(target_os = "emscripten", target_os = "fuchsia", target_os = "horizon")))]
         rtassert!(signal(libc::SIGPIPE, libc::SIG_IGN) != libc::SIG_ERR);
     }
 }


### PR DESCRIPTION
With `3dslink` and the [hbmenu](https://github.com/fincs/new-hbmenu) there is builtin support for passing argv directly to a 3dsx binary. This enables reading them instead of the stub implementation used by `espidf`.

Example, with this patch and latest version of `3dslink` and `hbmenu`:
```rust
//...
println!("{:?}", std::env::args().collect::<Vec<_>>());
//...
```

```sh
3dslink target/armv6k-nintendo-3ds/debug/examples/hello-world.3dsx -0 hello-world -- --x -y z
```

![argv-example](https://user-images.githubusercontent.com/11131775/153340388-4f9e3fd4-efc7-4544-b42b-23f62a44209b.png)


@Meziu @AzureMarker 