### PR TITLE
Enable #[thread_local] on armv6k-nintendo-3ds

### DIFF
--- a/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
+++ b/compiler/rustc_target/src/spec/armv6k_nintendo_3ds.rs
@@ -37,6 +37,7 @@ pub fn target() -> Target {
             pre_link_args,
             exe_suffix: ".elf".to_string(),
             no_default_libraries: false,
+            has_thread_local: true,
             ..Default::default()
         },
     }


### PR DESCRIPTION
Closes #15 

This does not work currently, there is a segfault happening in the [thread local destructor here](https://github.com/Meziu/rust-horizon/blob/horizon-std/library/std/src/sys_common/thread_local_dtor.rs#L43). It seems the `ptr` there is incorrect somehow, causing a page fault. 

Still investigating but thought I would open the PR in the meantime.

@AzureMarker @Meziu 