### PR TITLE
Remove support for env and process functionality

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -129,12 +129,12 @@ pub fn error_string(errno: i32) -> String {
     }
 }
 
-#[cfg(target_os = "espidf")]
+#[cfg(any(target_os = "espidf", target_os = "horizon"))]
 pub fn getcwd() -> io::Result<PathBuf> {
     Ok(PathBuf::from("/"))
 }
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 pub fn getcwd() -> io::Result<PathBuf> {
     let mut buf = Vec::with_capacity(512);
     loop {
@@ -161,12 +161,12 @@ pub fn getcwd() -> io::Result<PathBuf> {
     }
 }
 
-#[cfg(target_os = "espidf")]
+#[cfg(any(target_os = "espidf", target_os = "horizon"))]
 pub fn chdir(p: &path::Path) -> io::Result<()> {
     super::unsupported::unsupported()
 }
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 pub fn chdir(p: &path::Path) -> io::Result<()> {
     let p: &OsStr = p.as_ref();
     let p = CString::new(p.as_bytes())?;
@@ -560,7 +560,7 @@ pub fn unsetenv(n: &OsStr) -> io::Result<()> {
     }
 }
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
 pub fn page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
 }

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -129,12 +129,12 @@ pub fn error_string(errno: i32) -> String {
     }
 }
 
-#[cfg(any(target_os = "espidf", target_os = "horizon"))]
+#[cfg(target_os = "espidf")]
 pub fn getcwd() -> io::Result<PathBuf> {
     Ok(PathBuf::from("/"))
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+#[cfg(not(target_os = "espidf"))]
 pub fn getcwd() -> io::Result<PathBuf> {
     let mut buf = Vec::with_capacity(512);
     loop {
@@ -560,7 +560,7 @@ pub fn unsetenv(n: &OsStr) -> io::Result<()> {
     }
 }
 
-#[cfg(not(any(target_os = "espidf", target_os = "horizon")))]
+#[cfg(not(target_os = "espidf"))]
 pub fn page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
 }

--- a/library/std/src/sys/unix/process/mod.rs
+++ b/library/std/src/sys/unix/process/mod.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "vxworks")] {
         #[path = "process_vxworks.rs"]
         mod process_inner;
-    } else if #[cfg(target_os = "espidf")] {
+    } else if #[cfg(any(target_os = "espidf", target_os = "horizon"))] {
         #[path = "process_unsupported.rs"]
         mod process_inner;
     } else {


### PR DESCRIPTION
Related to #6 

Removed `process` support and changed `env` functions to avoid unsupported functionality. Tell me if anything else is left to remove, we can do one big cleanup here.

@AzureMarker @ian-h-chamberlain